### PR TITLE
Update utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -40,11 +40,11 @@ const switchVersionInFile = (project_type, new_version, file_path='./') => {
             break;
     
         case packageTypes.PYTHON:
+            new_version = new_version.replace("-", "+")
             let setupPy = fs.readFileSync(file_path + project_type, 'utf8')
             setupPy = setupPy.replace(pythonRegex, `${new_version}`)
             fs.writeFileSync(file_path + project_type, setupPy)
             break;
-    
     
         case packageTypes.CONAN:
             let conanFile = fs.readFileSync(file_path + project_type, 'utf8')


### PR DESCRIPTION
Replace first '-' with a '+' in order to adhere to [PEP 440 Local version identifiers](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers).

The new final (after normalization) package version can be printed by using:
`cat ./*.egg-info/PKG-INFO | awk '/^Name:/ {printf $2"=="} /^Version:/ {print $2}'`
inside the build directory